### PR TITLE
errors.Is implementation

### DIFF
--- a/serum_test.go
+++ b/serum_test.go
@@ -1,0 +1,114 @@
+package serum_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/serum-errors/go-serum"
+)
+
+func TestErrorsIs(t *testing.T) {
+	nonSerumErr := fmt.Errorf("non-serum")
+	nonSerumWrapped := fmt.Errorf("wrap: %w", nonSerumErr)
+	t.Run("sanity check", func(t *testing.T) {
+		if !errors.Is(nonSerumWrapped, nonSerumErr) {
+			t.Fatal("fmt.Errorf wrapping should be fine")
+		}
+	})
+	eqSynth := func(t *testing.T, a, b error, expectEqual bool) {
+		ai, ok := a.(serum.ErrorInterface)
+		if !ok {
+			t.Fatalf("%T is not a a serum.ErrorInterface", a)
+		}
+		bi, ok := b.(serum.ErrorInterface)
+		if !ok {
+			t.Fatalf("%T is not a a serum.ErrorInterface", b)
+		}
+		as := serum.SynthesizeString(ai)
+		bs := serum.SynthesizeString(bi)
+		if (as == bs) != expectEqual {
+			t.Fatalf("unexpected message synthesis:\n%s\n%s", as, bs)
+		}
+	}
+	t.Run("equivalent serum errors", func(t *testing.T) {
+		// should fail if !errors.Is
+		t.Run("with only codes", func(t *testing.T) {
+			a := serum.Error("test")
+			b := serum.Error("test")
+			if !errors.Is(a, b) {
+				t.Fatal("errors should be equivalent")
+			}
+			eqSynth(t, a, b, true)
+		})
+		t.Run("with literal messages", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageLiteral("a thing!"))
+			b := serum.Error("test", serum.WithMessageLiteral("a thing!"))
+			if !errors.Is(a, b) {
+				t.Fatal("errors should be equivalent")
+			}
+			eqSynth(t, a, b, true)
+		})
+		t.Run("with untemplated details", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("foo", "bar"))
+			b := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("bar", "grill"))
+			if !errors.Is(a, b) {
+				t.Fatal("we don't care about details which don't synthesize into the message")
+			}
+			eqSynth(t, a, b, true)
+		})
+		t.Run("with matching templated details", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageLiteral("the thing is {{foo}}"), serum.WithDetail("foo", "bar"))
+			b := serum.Error("test", serum.WithMessageLiteral("the thing is {{foo}}"), serum.WithDetail("foo", "bar"))
+			if !errors.Is(a, b) {
+				t.Fatal("errors that synthesize to equivalent messages should be equivalent")
+			}
+			eqSynth(t, a, b, true)
+		})
+		t.Run("with non-serum cause", func(t *testing.T) {
+			withCause := serum.Error("test", serum.WithCause(nonSerumErr))
+			if !errors.Is(withCause, nonSerumErr) {
+				t.Fatal("unable to use errors.Is with a non-serum error")
+			}
+		})
+		t.Run("with wrapped non-serum cause", func(t *testing.T) {
+			withCauseWrapped := serum.Error("test", serum.WithCause(nonSerumWrapped))
+			if !errors.Is(withCauseWrapped, nonSerumErr) {
+				t.Fatal("unable to use errors.Is with a wrapped non-serum error")
+			}
+		})
+		t.Run("with serum cause", func(t *testing.T) {
+			err := serum.Error("test", serum.WithMessageLiteral("thing!"))
+			wrapper := serum.Error("test-wrapper", serum.WithCause(err))
+			if !errors.Is(wrapper, err) {
+				t.Fatal("serum-cause wrapping should resolve")
+			}
+		})
+	})
+	t.Run("non-equivalent serum errors", func(t *testing.T) {
+		t.Run("with different codes", func(t *testing.T) {
+			a := serum.Error("test")
+			b := serum.Error("other-test")
+			if errors.Is(a, b) {
+				t.Fatal("errors with different codes should not be considered equal")
+			}
+			eqSynth(t, a, b, false)
+		})
+		t.Run("with different messages", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageLiteral("foo"))
+			b := serum.Error("test", serum.WithMessageLiteral("bar"))
+			if errors.Is(a, b) {
+				t.Fatal("errors with different codes should not be considered equal")
+			}
+			eqSynth(t, a, b, false)
+		})
+		t.Run("with non-matching templated details", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageTemplate("a thing: {{foo}}"), serum.WithDetail("foo", "bar"))
+			b := serum.Error("test", serum.WithMessageTemplate("a thing: {{foo}}"), serum.WithDetail("foo", "grill"))
+			if errors.Is(a, b) {
+				t.Fatal("errors with templated messages that synthesize differently should not be considered equal")
+			}
+			eqSynth(t, a, b, false)
+		})
+	})
+}

--- a/serum_test.go
+++ b/serum_test.go
@@ -1,6 +1,8 @@
 package serum_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -8,29 +10,44 @@ import (
 	"github.com/serum-errors/go-serum"
 )
 
+func eqJson(t *testing.T, a, b error, expectEqual bool) {
+	aj, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", a)
+	}
+	bj, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Failed to serialize: %v", b)
+	}
+	if (bytes.Compare(aj, bj) == 0) != expectEqual {
+		t.Fatalf("unexpected error serialization:\n%s\n%s", string(aj), string(bj))
+	}
+}
+
+func eqSynth(t *testing.T, a, b error, expectEqual bool) {
+	ai, ok := a.(serum.ErrorInterface)
+	if !ok {
+		t.Fatalf("%T is not a a serum.ErrorInterface", a)
+	}
+	bi, ok := b.(serum.ErrorInterface)
+	if !ok {
+		t.Fatalf("%T is not a a serum.ErrorInterface", b)
+	}
+	as := serum.SynthesizeString(ai)
+	bs := serum.SynthesizeString(bi)
+	if (as == bs) != expectEqual {
+		t.Fatalf("unexpected message synthesis:\n%s\n%s", as, bs)
+	}
+}
+
 func TestErrorsIs(t *testing.T) {
-	nonSerumErr := fmt.Errorf("non-serum")
+	nonSerumErr := errors.New("non-serum")
 	nonSerumWrapped := fmt.Errorf("wrap: %w", nonSerumErr)
 	t.Run("sanity check", func(t *testing.T) {
 		if !errors.Is(nonSerumWrapped, nonSerumErr) {
 			t.Fatal("fmt.Errorf wrapping should be fine")
 		}
 	})
-	eqSynth := func(t *testing.T, a, b error, expectEqual bool) {
-		ai, ok := a.(serum.ErrorInterface)
-		if !ok {
-			t.Fatalf("%T is not a a serum.ErrorInterface", a)
-		}
-		bi, ok := b.(serum.ErrorInterface)
-		if !ok {
-			t.Fatalf("%T is not a a serum.ErrorInterface", b)
-		}
-		as := serum.SynthesizeString(ai)
-		bs := serum.SynthesizeString(bi)
-		if (as == bs) != expectEqual {
-			t.Fatalf("unexpected message synthesis:\n%s\n%s", as, bs)
-		}
-	}
 	t.Run("equivalent serum errors", func(t *testing.T) {
 		// should fail if !errors.Is
 		t.Run("with only codes", func(t *testing.T) {
@@ -40,6 +57,7 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors should be equivalent")
 			}
 			eqSynth(t, a, b, true)
+			eqJson(t, a, b, true)
 		})
 		t.Run("with literal messages", func(t *testing.T) {
 			a := serum.Error("test", serum.WithMessageLiteral("a thing!"))
@@ -48,14 +66,16 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors should be equivalent")
 			}
 			eqSynth(t, a, b, true)
+			eqJson(t, a, b, true)
 		})
-		t.Run("with untemplated details", func(t *testing.T) {
+		t.Run("with matching untemplated details", func(t *testing.T) {
 			a := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("foo", "bar"))
-			b := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("bar", "grill"))
+			b := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("foo", "bar"))
 			if !errors.Is(a, b) {
 				t.Fatal("we don't care about details which don't synthesize into the message")
 			}
 			eqSynth(t, a, b, true)
+			eqJson(t, a, b, true)
 		})
 		t.Run("with matching templated details", func(t *testing.T) {
 			a := serum.Error("test", serum.WithMessageLiteral("the thing is {{foo}}"), serum.WithDetail("foo", "bar"))
@@ -64,6 +84,7 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors that synthesize to equivalent messages should be equivalent")
 			}
 			eqSynth(t, a, b, true)
+			eqJson(t, a, b, true)
 		})
 		t.Run("with non-serum cause", func(t *testing.T) {
 			withCause := serum.Error("test", serum.WithCause(nonSerumErr))
@@ -93,6 +114,7 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors with different codes should not be considered equal")
 			}
 			eqSynth(t, a, b, false)
+			eqJson(t, a, b, false)
 		})
 		t.Run("with different messages", func(t *testing.T) {
 			a := serum.Error("test", serum.WithMessageLiteral("foo"))
@@ -101,6 +123,7 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors with different codes should not be considered equal")
 			}
 			eqSynth(t, a, b, false)
+			eqJson(t, a, b, false)
 		})
 		t.Run("with non-matching templated details", func(t *testing.T) {
 			a := serum.Error("test", serum.WithMessageTemplate("a thing: {{foo}}"), serum.WithDetail("foo", "bar"))
@@ -109,6 +132,17 @@ func TestErrorsIs(t *testing.T) {
 				t.Fatal("errors with templated messages that synthesize differently should not be considered equal")
 			}
 			eqSynth(t, a, b, false)
+			eqJson(t, a, b, false)
+		})
+		t.Run("with non-matching untemplated details", func(t *testing.T) {
+			a := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("foo", "bar"))
+			b := serum.Error("test", serum.WithMessageLiteral("a thing!"), serum.WithDetail("bar", "grill"))
+			if errors.Is(a, b) {
+				t.Fatal("details must be equivalent")
+			}
+			// This case is weird. It's the only one with different equivalence for string-synthesis and serialization.
+			eqSynth(t, a, b, true)
+			eqJson(t, a, b, false)
 		})
 	})
 }

--- a/struct.go
+++ b/struct.go
@@ -55,14 +55,25 @@ func (e *ErrorValue) Error() string { return SynthesizeString(e) }
 // Is implements errors.Is so that it works for non-serum errors
 // This allows non-serum-aware packages to take serum errors if they use errors.Is for error comparisons
 func (e *ErrorValue) Is(target error) bool {
-	if Code(e) != Code(target) {
+	if e.Data.Code != Code(target) {
 		return false
 	}
-	if Message(e) != Message(target) {
+	if e.Data.Message != Message(target) {
 		return false
+	}
+	tard := Details(target)
+	if len(e.Data.Details) != len(tard) {
+		return false
+	}
+	for i, v := range e.Data.Details {
+		if v[0] != tard[i][0] {
+			return false
+		}
+		if v[1] != tard[i][1] {
+			return false
+		}
 	}
 	// We don't check detail map because it _should_ be synthesized into message.
 	// We should not unwrap here because errors.Is handles unwrapping.
 	return true
 }
- 

--- a/struct.go
+++ b/struct.go
@@ -51,3 +51,18 @@ func (e *ErrorValue) Unwrap() error { return e.Data.Cause }
 
 // Error implements the golang error interface.  The returned string will contain the code, the message if present, and the string of the cause.  Per Serum convention, it does not include any of the details fields.
 func (e *ErrorValue) Error() string { return SynthesizeString(e) }
+
+// Is implements errors.Is so that it works for non-serum errors
+// This allows non-serum-aware packages to take serum errors if they use errors.Is for error comparisons
+func (e *ErrorValue) Is(target error) bool {
+	if Code(e) != Code(target) {
+		return false
+	}
+	if Message(e) != Message(target) {
+		return false
+	}
+	// We don't check detail map because it _should_ be synthesized into message.
+	// We should not unwrap here because errors.Is handles unwrapping.
+	return true
+}
+ 


### PR DESCRIPTION
This allows us to do comparisons across package boundaries and makes go-serum more compatible with modern idiomatic go.

The following should return true and would allow users to pass and use go-serum errors like other errors for comparison. 
```go
err := serum.Error("missing!", serum.WithCause(fs.ErrNotExist))
fmt.Println(errors.Is(err, fs.ErrNotExist))
```
